### PR TITLE
Fix type hints for decorators

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ validators = "^0.20.0"
 aiohttp = "^3.8.3"
 pyrate-limiter = "^2.8.4"
 backoff = "^2.2.1"
+typing-extensions = "^4.4.0"
 
 [tool.poetry.dev-dependencies]
 pylint = "^2.15.9"

--- a/shikithon/decorators/method_endpoint.py
+++ b/shikithon/decorators/method_endpoint.py
@@ -1,16 +1,17 @@
 """Decorator for method endpoint logging"""
-from __future__ import annotations
-
-from typing import Any, Callable, Dict, Tuple, TypeVar
+from functools import wraps
+from typing import Callable, TypeVar
 
 from loguru import logger
+from typing_extensions import ParamSpec
 
-RT = TypeVar('RT')
+P = ParamSpec('P')
+R = TypeVar('R')
 
 
 def method_endpoint(
-    method_endpoint_name: str
-) -> Callable[[Callable[..., RT]], Callable[..., RT]]:
+        method_endpoint_name: str
+) -> Callable[[Callable[P, R]], Callable[P, R]]:
     """
     Decorator for logging method endpoint.
 
@@ -18,34 +19,33 @@ def method_endpoint(
     :type method_endpoint_name: str
 
     :return: Decorator function
-    :rtype: Callable[[Callable[..., RT]], Callable[..., RT]]
+    :rtype: Callable[[Callable[P, R]], Callable[P, R]]
     """
 
-    def endpoint_logger_decorator(
-            function: Callable[..., RT]) -> Callable[..., RT]:
+    def endpoint_logger_decorator(function: Callable[P, R]) -> Callable[P, R]:
         """Endpoint logger decorator.
 
         :param function: Function to decorate
-        :type function: Callable[..., RT]
+        :type function: Callable[P, R]
 
         :return: Decorated function
-        :rtype: Callable[..., RT]
+        :rtype: Callable[P, R]
         """
 
-        def endpoint_logger_wrapper(*args: Tuple[Any],
-                                    **kwargs: Dict[str, Any]) -> RT:
+        @wraps(function)
+        def endpoint_logger_wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
             """
             Decorator's wrapper function.
             Logs endpoint of method
 
             :param args: Positional arguments
-            :type args: Tuple[Any]
+            :type args: P.args
 
             :param kwargs: Keyword arguments
-            :type kwargs: Dict[str, Any]
+            :type kwargs: P.kwargs
 
             :return: Result of decorated function
-            :rtype: RT
+            :rtype: R
             """
             logger.debug(f'Executing "{method_endpoint_name}" method')
             return function(*args, **kwargs)


### PR DESCRIPTION
Исправил декораторы, чтобы они не подменяли название, строку документации и т.д.
Добавил в зависимости typing-extensions (также есть в зависимостях у pydantic).
Исправил подсказки типов для декораторов, чтобы показывались аргументы, а не три точки (на скриншоте показано как теперь это выглядит).
![Снимок экрана 2023-01-04 в 20 20 50](https://user-images.githubusercontent.com/51508179/210613091-a36574ca-4fe0-47a4-90bb-0a9a2579ead4.png)

Код:
```python
from shikithon import ShikimoriAPI
import asyncio


async def main():
    api = ShikimoriAPI("Api Test", logging=False)
    m = api.animes.create_video
    print(m.__module__)
    print(m.__name__)
    print(m.__qualname__)
    print(m.__doc__)
    print(m.__annotations__)


asyncio.run(main())
```
Раньше:
```
shikithon.decorators.protected_method
protected_method_wrapper
protected_method.<locals>.protected_method_decorator.<locals>.protected_method_wrapper

            Decorator's wrapper function.

            Check for token expire time.
            If needed, triggers token refresh function.

            :param self: Resource instance
            :type self: BaseResource

            :param args: Positional arguments
            :type args: Tuple[Any]

            :param kwargs: Keyword arguments
            :type kwargs: Any

            :return: Fallback function if API object is in restricted mode
                or if required scope is missing
            :rtype: RT
            
{'self': 'BaseResource', 'args': 'Tuple[Any]', 'kwargs': 'Any', 'return': 'RT'}
```
Теперь:
```
shikithon.resources.animes
create_video
Animes.create_video

        Creates anime video.

        :param anime_id: Anime ID to create video
        :type anime_id: int

        :param kind: Kind of video
        :type kind: str

        :param name: Name of video
        :type name: str

        :param url: URL of video
        :type url: str

        :return: Created video info
        :rtype: Optional[Video]
        
{'anime_id': <class 'int'>, 'kind': <class 'str'>, 'name': <class 'str'>, 'url': <class 'str'>, 'return': typing.Union[shikithon.models.video.Video, NoneType]}
```